### PR TITLE
Fixing NoMethodError undefined method `retart'

### DIFF
--- a/lib/guard/webpack.rb
+++ b/lib/guard/webpack.rb
@@ -20,7 +20,7 @@ module Guard
 
     def run_on_modifications(p);  @runner.restart;  end
     def run_all;                  @runner.restart;  end
-    def reload;                   @runner.retart;   end
+    def reload;                   @runner.restart;  end
     def start;                    @runner.start;    end
     def stop;                     @runner.stop;     end
 


### PR DESCRIPTION
Using the command `reload` while guard is running produces the following error

```
10:04:26 - ERROR - Guard::Webpack failed to achieve its <reload>, exception was:
> [#7BDDA8560CC2] NoMethodError: undefined method `retart' for #<Guard::Webpack::Runner:0x007fc6e3426ee8>
```

This PR addresses this exception 